### PR TITLE
Support hosting in a subdirectory

### DIFF
--- a/nginx-example
+++ b/nginx-example
@@ -1,0 +1,34 @@
+# Example nginx site for hosting codenames.plus in a subdirectory.
+
+server {
+	listen 443 ssl http2;
+	listen 443 [::]:443 ssl http2;
+
+	server_name example.com;
+
+	# Host codenames.plus at https://example.com/codenames-plus/
+	# Based on https://stackoverflow.com/a/11466351
+	location /codenames-plus {
+		rewrite /codenames-plus$ codenames-plus/ permanent;
+
+		alias /var/www/codenames-plus/public/;
+		try_files $uri $uri/ $uri/index.html @codenames-plus;
+	}
+	location @codenames-plus {
+		rewrite /codenames-plus(.+) $1 break;
+
+		proxy_set_header X-Real-IP $remote_addr;
+		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+		proxy_set_header Host $http_host;
+		proxy_set_header X-NginX-Proxy true;
+
+		# Forward to node listening on http://localhost:2000/
+		proxy_pass http://localhost:2000;
+		proxy_redirect http://localhost:2000/ /codenames-plus/;
+
+		# Support WebSockets
+		proxy_http_version 1.1;
+		proxy_set_header Upgrade $http_upgrade;
+		proxy_set_header Connection "upgrade";
+	}
+}

--- a/public/js/codenames.js
+++ b/public/js/codenames.js
@@ -1,4 +1,4 @@
-let socket = io() // Connect to server
+let socket = io({path: window.location.pathname + 'socket.io'}) // Connect to server
 
 
 // Sign In Page Elements


### PR DESCRIPTION
The call to Socket.io assumed the server is being hosted at the root of the domain. This small change makes it use the directory it is hosted from instead. I also included my nginx configuration which I use to host it in a subdirectory on my server (at https://apps.aweirdimagination.net/codenames-plus/).